### PR TITLE
PlatformConfig.mk: don't set PRODUCT_BUILD_RECOVERY_IMAGE twice

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -82,7 +82,6 @@ BOARD_MOVE_GSI_AVB_KEYS_TO_VENDOR_BOOT := true
 BOARD_RECOVERYIMAGE_PARTITION_SIZE := 104857600
 BOARD_EXCLUDE_KERNEL_FROM_RECOVERY_IMAGE := true
 BOARD_COPY_BOOT_IMAGE_TO_TARGET_FILES :=
-PRODUCT_BUILD_RECOVERY_IMAGE := true
 
 # https://source.android.com/devices/bootloader/partitions/vendor-boot-partitions#build-support
 # >= 3 is required for (and turns on) PRODUCT_BUILD_VENDOR_BOOT_IMAGE


### PR DESCRIPTION
It's set in device/sony/common/common.mk and AOSP build really
dislikes it when it's set here and you run `make -jN`, but does
not care at all if you make bootimage/vendorbootimage/recoveryimage

we live in a society, i guess