### PR TITLE
Add Xperia 5 IV (pdx224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Android device configuration for the nagara platform (**SM8450**).
 | Device | Codename |
 |-|:-:|
 | Xperia 1 IV | [pdx223](https://github.com/sonyxperiadev/device-sony-pdx223) |
+| Xperia 5 IV | [pdx224](https://github.com/sonyxperiadev/device-sony-pdx224) |
 
 ### Build instructions
 

--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -36,6 +36,10 @@ static inline const char* getBTDefaultName()
         return "Xperia 1 IV";
     }
 
+    if (!strcmp("pdx224", device)) {
+        return "Xperia 5 IV";
+    }
+
     return "Xperia";
 }
 


### PR DESCRIPTION
We originally omitted this as the 5 IV wasn't out/supported yet when 1IV was brought up.
