### PR TITLE
PlatformConfig: Remove 1IV-specific framebuffer-console cmdline suggestion

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -25,9 +25,6 @@ BOARD_KERNEL_PAGESIZE    := 4096
 BOARD_KERNEL_TAGS_OFFSET := 0x00000100
 BOARD_RAMDISK_OFFSET     := 0x01000000
 
-# FB console
-#BOARD_KERNEL_CMDLINE += earlycon=simplefb,0xb8000000,1096,2560
-
 # Serial console
 #BOARD_KERNEL_CMDLINE += earlycon=msm_geni_serial,0xa90000
 


### PR DESCRIPTION
5IV has a smaller screen and with it comes a smaller default resolution (1080x2520) to match the bootloader-configured simplefb resolution.  Remove the suggested kernel cmdline that only applies to 1IV from the platform repository: the correct config has been added to both 1IV (pdx223) and 5IV (pdx224) device repositories.

https://github.com/sonyxperiadev/device-sony-pdx224/pull/3
https://github.com/sonyxperiadev/device-sony-pdx223/pull/6
