### PR TITLE
platform: Move `android.hardware.security.keymint` AIDL lib to `/vendor`

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -247,6 +247,7 @@ PRODUCT_PACKAGES += \
 # (executable is on odm)
 PRODUCT_PACKAGES += \
     android.hardware.security.keymint-V1-ndk_platform.vendor \
+    libkeymaster_messages.vendor \
     android.hardware.keymaster@4.1-service-qti.rc \
     android.hardware.keymaster@4.1.vendor \
     android.hardware.security.keymint-service-qti.rc \

--- a/platform.mk
+++ b/platform.mk
@@ -246,7 +246,7 @@ PRODUCT_PACKAGES += \
 # Keymaster 4 passthrough service init file
 # (executable is on odm)
 PRODUCT_PACKAGES += \
-    android.hardware.security.keymint-V1-ndk_platform \
+    android.hardware.security.keymint-V1-ndk_platform.vendor \
     android.hardware.keymaster@4.1-service-qti.rc \
     android.hardware.keymaster@4.1.vendor \
     android.hardware.security.keymint-service-qti.rc \


### PR DESCRIPTION
The `ndk_platform` libraries end up on the `/system` partition, but we need them on the `/vendor` partition to be available from the vndk for this `keymint` QTI ODM binary to load them:

    I init    : starting service 'vendor.keymint-qti'...
    F linker  : CANNOT LINK EXECUTABLE "/odm/bin/hw/android.hardware.security.keymint-service-qti": library "android.hardware.security.keymint-V1-ndk_platform.so" not found: needed by main executable
    I init    : Service 'vendor.keymint-qti' (pid 5298) exited with status 1
    I init    : Sending signal 9 to service 'vendor.keymint-qti' (pid 5298) process group...

Note that the `ndk_platform` target will be removed in the future, so we should seek to switch this back to just an `ndk` dependency.

Fixes: bd70796 ("platform: add keymint-V1-ndk_platform")

---

We're going to need more ODM libraries to get this service started though:

    04-07 11:28:00.810  3467  3467 F linker  : CANNOT LINK EXECUTABLE "/odm/bin/hw/android.hardware.security.keymint-service-qti": library "libkeymaster_messages.so" not found: needed by /odm/lib64/libqtikeymint.so in namespace (default)
