### PR TITLE
[t-mr1] vendor: ueventd: Avoid setting permission for /dev/hw_random

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -92,7 +92,6 @@ subsystem mem_buf_vm
 /dev/system_health_monitor 0640  radio      system
 /dev/mdss_rotator         0664   system     system
 /dev/msm_rotator          0660   system     system
-/dev/hw_random            0660   system     system
 /dev/adsprpc-smd          0664   system     system
 /dev/adsprpc-smd-secure   0664   system     system
 /dev/sdsprpc-smd          0664   system     system


### PR DESCRIPTION
Below patch from system/core is setting required access policy
for /dev/hw_random. And CTS test is updated accordingly

https://android-review.googlesource.com/c/platform/system/core/+/2229337
https://android-review.googlesource.com/c/platform/cts/+/2232052

Change-Id: I762dfa3b1e84dee6c49fc178b5b75cf1c134cfb7

---
Valid for all our devices running Android 13+.
Fixes:
```
01-01 00:00:04.160   402   402 W prng_seeder: Hanging forever because setup failed: Unable to open hwrng /dev/hw_random
01-01 00:00:04.161   402   402 W Caused by:  
01-01 00:00:04.162   402   402 W         : Permission denied (os error 13)
```