### PR TITLE
[t-mr1] Fix offline charger

### DIFF
--- a/rootdir/vendor/etc/init/init.nagara.rc
+++ b/rootdir/vendor/etc/init/init.nagara.rc
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+on charger
+    # Mount filesystems
+    trigger fs
+    # Bring ADSP out of reset
+    start vendor.adspstart_sh
+    # Restart charger after ADSP is out of reset
+    restart vendor.charger
+
 on post-fs
     rm /persist/bluetooth/.bt_nv.bin
     rmdir /persist/bluetooth


### PR DESCRIPTION
To support offline charging mode, modem partition should get mounted to bring ADSP out of reset and thereby allowing PMIC Glink and its clients (battery charger driver) to probe.

Since ADSP firmware is part of modem partition,
add a charger trigger and perform the following steps:
  1. trigger fs (to mount modem partition).
  2. start vendor.adspstart_sh (to bring ADSP out of reset).
  3. restart charger after ADSP is out of reset (restart is necessary for correct initialization of the service).