### PR TITLE
[u-mr1] platform: Provide missing KeyMint dependencies on vendor

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -236,6 +236,9 @@ PRODUCT_PACKAGES += \
 # (executable is on odm)
 PRODUCT_PACKAGES += \
     android.hardware.security.keymint-V1-ndk_platform.vendor \
+    android.hardware.security.keymint-V2-ndk.vendor \
+    android.hardware.security.rkp-V3-ndk.vendor \
+    android.hardware.security.sharedsecret-V1-ndk.vendor \
     libkeymaster_messages.vendor \
     android.hardware.keymaster@4.1.vendor \
     android.hardware.security.keymint-service-qti.rc \


### PR DESCRIPTION
The following libraries are dependencies of KeyMint and
are no longer shipped with VNDK, hence they need to be
explicitly built.

android.hardware.security.keymint-V2-ndk
android.hardware.security.rkp-V3-ndk
android.hardware.security.sharedsecret-V1-ndk